### PR TITLE
Add TSB keyword search prototype

### DIFF
--- a/tsb_keyword_search/README.md
+++ b/tsb_keyword_search/README.md
@@ -1,0 +1,19 @@
+# Simple TSB Keyword Search Prototype
+
+This prototype demonstrates a minimal web interface for searching potential Technical Service Bulletins (TSB) indicators using NHTSA data.
+
+## Requirements
+- Python 3
+- `flask` and `requests` packages
+
+Install dependencies:
+```bash
+pip install flask requests
+```
+
+## Usage
+Run the application from this directory:
+```bash
+python app.py
+```
+Visit `http://localhost:5000` in a browser.

--- a/tsb_keyword_search/app.py
+++ b/tsb_keyword_search/app.py
@@ -1,0 +1,102 @@
+from flask import Flask, render_template, request
+import requests
+
+app = Flask(__name__)
+
+NHTSA_RECALLS_URL = "https://api.nhtsa.gov/recalls/recallsByVehicle"
+NHTSA_COMPLAINTS_URL = "https://api.nhtsa.gov/complaints/complaintsByVehicle"
+NHTSA_INVESTIGATIONS_URL = "https://api.nhtsa.gov/SafetyIssues"
+
+@app.route('/', methods=['GET'])
+def index():
+    return render_template('search.html')
+
+@app.route('/search', methods=['POST'])
+def search():
+    keywords = request.form['keywords']
+    year = request.form['year']
+    make = request.form['make']
+    model = request.form.get('model', '')
+
+    results = search_nhtsa_data(keywords, year, make, model)
+    return render_template('search.html', results=results, keywords=keywords)
+
+# --- Search logic helpers ---
+
+def search_nhtsa_data(keywords, year, make, model):
+    recalls = search_recalls(year, make, model)
+    complaints = search_complaints(year, make, model)
+    investigations = search_investigations(year, make, model)
+    scored_recalls = match_and_score(recalls, 'Summary', keywords)
+    scored_complaints = match_and_score(complaints, 'Summary', keywords)
+    scored_investigations = match_and_score(investigations, 'Summary', keywords)
+    return {
+        'recalls': scored_recalls,
+        'complaints': scored_complaints,
+        'investigations': scored_investigations
+    }
+
+
+def search_recalls(year, make, model):
+    params = {'make': make, 'modelYear': year}
+    if model:
+        params['model'] = model
+    try:
+        r = requests.get(NHTSA_RECALLS_URL, params=params, timeout=10)
+        r.raise_for_status()
+        return r.json().get('results', [])
+    except Exception:
+        return []
+
+
+def search_complaints(year, make, model):
+    params = {'make': make, 'modelYear': year}
+    if model:
+        params['model'] = model
+    try:
+        r = requests.get(NHTSA_COMPLAINTS_URL, params=params, timeout=10)
+        r.raise_for_status()
+        return r.json().get('results', [])
+    except Exception:
+        return []
+
+
+def search_investigations(year, make, model):
+    params = {'make': make, 'modelYear': year}
+    if model:
+        params['model'] = model
+    try:
+        r = requests.get(NHTSA_INVESTIGATIONS_URL, params=params, timeout=10)
+        r.raise_for_status()
+        return r.json().get('results', [])
+    except Exception:
+        return []
+
+
+def match_and_score(items, field, keywords):
+    matches = []
+    for item in items:
+        text = item.get(field, '')
+        score = calculate_relevance_score(text, keywords)
+        if score > 0:
+            matches.append({
+                'score': score,
+                'data': item
+            })
+    matches.sort(key=lambda x: x['score'], reverse=True)
+    return matches
+
+
+def calculate_relevance_score(text, keywords):
+    score = 0
+    text_lower = text.lower()
+    for keyword in keywords.split():
+        if keyword.lower() in text_lower:
+            score += 1
+            if keyword.lower() in ['stall', 'brake', 'airbag', 'fire']:
+                score += 2
+    return score
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/tsb_keyword_search/templates/search.html
+++ b/tsb_keyword_search/templates/search.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>TSB Keyword Search</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2rem; }
+        form div { margin-bottom: 1rem; }
+    </style>
+</head>
+<body>
+<h1>Search Potential TSB Indicators</h1>
+<form method="post" action="/search">
+    <div>
+        <label>Keywords:</label>
+        <input type="text" name="keywords" required>
+    </div>
+    <div>
+        <label>Year:</label>
+        <select name="year">
+            {% for y in range(2015, 2026) %}
+            <option value="{{ y }}">{{ y }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div>
+        <label>Make:</label>
+        <select name="make">
+            <option>Mercedes</option>
+            <option>BMW</option>
+            <option>Ford</option>
+            <option>Toyota</option>
+            <option>Honda</option>
+        </select>
+    </div>
+    <div>
+        <label>Model (optional):</label>
+        <input type="text" name="model">
+    </div>
+    <button type="submit">Search</button>
+</form>
+{% if results %}
+<h2>Results for "{{ keywords }}"</h2>
+<pre>{{ results|tojson(indent=2) }}</pre>
+{% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a small Flask app for searching NHTSA data
- provide HTML form for input fields
- include a README with setup instructions

## Testing
- `python -m py_compile tsb_keyword_search/app.py`
- ❌ `pip install flask requests` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6854d3c4ee308330b16ac6d9a4177afe